### PR TITLE
Add language specification to HTML tag

### DIFF
--- a/views/layout.pug
+++ b/views/layout.pug
@@ -1,7 +1,7 @@
 include mixins.pug
 
 doctype html
-html
+html(lang='en')
 	head
 		meta(charset='utf-8')
 		meta(name='viewport' content='width=device-width, initial-scale=1, shrink-to-fit=no')


### PR DESCRIPTION
Chrome occasionally suggests to that part of the page is in another language and offers to translate at the top of the page. I think it's when there is a diacritic mark in the name of one of the SP's. This should put a stop to that.